### PR TITLE
Added tests that operate on top of TestValue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - "1.10.x"
   - "1.11.x"
+  - "1.18.x"
+  - "1.19.x"
+  - "1.20.x"
 
 before_install:
   - go get -t -v ./...

--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ From a configured [Go environment](https://golang.org/doc/install#testing):
 go get -u github.com/ef-ds/benchmark
 ```
 
-If you are using dep:
-```sh
-dep ensure -add github.com/ef-ds/benchmark@1.0.1
-```
-
 We recommend to target only released versions for production use.
 
 

--- a/fill-test.go
+++ b/fill-test.go
@@ -44,3 +44,23 @@ func (t *Tests) Fill(b *testing.B, initInstance func(), add func(v interface{}),
 		})
 	}
 }
+
+// FillTestObject test the data structures performance by sequentially adding n items to the data structure and then removing all added items.
+// FillTestObject tests the data structures ability for quickly expand and shrink.
+// FillTestObject is a copy of Fill that operates on *TestValue object which allows data structures that suport
+// generics to not need to perform any type cast in the benchmark tests.
+func (t *Tests) FillTestObject(b *testing.B, initInstance func(), add func(v *TestValue), remove func() (*TestValue, bool), empty func() bool) {
+	for _, test := range tests {
+		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				initInstance()
+				for i := 0; i < test.count; i++ {
+					add(GetTestValue(i))
+				}
+				for !empty() {
+					tmp, tmp2 = remove()
+				}
+			}
+		})
+	}
+}

--- a/refill-full-test.go
+++ b/refill-full-test.go
@@ -62,3 +62,41 @@ func (t *Tests) RefillFull(b *testing.B, initInstance func(), add func(v interfa
 		tmp, tmp2 = remove()
 	}
 }
+
+// RefillFullTestObject test the data structures performance by sequentially adding n items to the data structures and then removing all added items
+// repeating the test 100 times using the same data structure instance. But before running the test, fills the data structures
+// with n items.
+// RefillFullTestObject rests the data structures ability to fill again once it has been filled and emptied back to a certain level.
+// RefillFullTestObject is a copy of RefillFull that operates on *TestValue object which allows data structures that suport
+// generics to not need to perform any type cast in the benchmark tests.
+func (t *Tests) RefillFullTestObject(b *testing.B, initInstance func(), add func(v *TestValue), remove func() (*TestValue, bool), empty func() bool) {
+	initInstance()
+	for i := 0; i < fillCount; i++ {
+		add(GetTestValue(i))
+	}
+
+	for i, test := range tests {
+		// Doesn't run the first (0 items) and last (1mi) items tests
+		// as 0 items makes no sense for this test and 1mi is too slow.
+		if i == 0 || i > 6 {
+			continue
+		}
+
+		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				for k := 0; k < refillCount; k++ {
+					for i := 0; i < test.count; i++ {
+						add(GetTestValue(i))
+					}
+					for i := 0; i < test.count; i++ {
+						tmp, tmp2 = remove()
+					}
+				}
+			}
+		})
+	}
+
+	for !empty() {
+		tmp, tmp2 = remove()
+	}
+}

--- a/refill-test.go
+++ b/refill-test.go
@@ -53,3 +53,32 @@ func (t *Tests) Refill(b *testing.B, initInstance func(), add func(v interface{}
 		})
 	}
 }
+
+// RefillTestObject test the data structures performance by sequentially adding n items to the data structure and then removing all added items
+// repeating the test 100 times using the same data structure instance.
+// RefillTestObject tests the data structures ability to fill again once it has been filled and emptied.
+// RefillTestObject is a copy of Refill that operates on *TestValue object which allows data structures that suport
+// generics to not need to perform any type cast in the benchmark tests.
+func (t *Tests) RefillTestObject(b *testing.B, initInstance func(), add func(v *TestValue), remove func() (*TestValue, bool), empty func() bool) {
+	for i, test := range tests {
+		// Doesn't run the first (0 items) and last (1mi) items tests
+		// as 0 items makes no sense for this test and 1mi is too slow.
+		if i == 0 || i > 6 {
+			continue
+		}
+
+		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
+			initInstance()
+			for n := 0; n < b.N; n++ {
+				for n := 0; n < refillCount; n++ {
+					for i := 0; i < test.count; i++ {
+						add(GetTestValue(i))
+					}
+					for !empty() {
+						tmp, tmp2 = remove()
+					}
+				}
+			}
+		})
+	}
+}

--- a/slow-decrease-test.go
+++ b/slow-decrease-test.go
@@ -61,3 +61,40 @@ func (t *Tests) SlowDecrease(b *testing.B, initInstance func(), add func(v inter
 		tmp, tmp2 = remove()
 	}
 }
+
+// SlowDecreaseTestObject tests the data structures performance by sequentially adding 2 items and then removing 1.
+// SlowDecreaseTestObject tests the data structures ability to slowly expand while removing some elements from the data structure.
+// SlowDecreaseTestObject is a copy of SlowDecrease that operates on *TestValue object which allows data structures that suport
+// generics to not need to perform any type cast in the benchmark tests.
+func (t *Tests) SlowDecreaseTestObject(b *testing.B, initInstance func(), add func(v *TestValue), remove func() (*TestValue, bool), empty func() bool) {
+	initInstance()
+	for _, test := range tests {
+		items := test.count / 2
+		for i := 0; i <= items; i++ {
+			add(GetTestValue(i))
+		}
+	}
+
+	for i, test := range tests {
+		// Doesn't run the first (0 items) test as 0 items makes no sense for this test.
+		if i == 0 {
+			continue
+		}
+
+		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				for i := 0; i < test.count; i++ {
+					add(GetTestValue(i))
+					tmp, tmp2 = remove()
+					if !empty() {
+						tmp, tmp2 = remove()
+					}
+				}
+			}
+		})
+	}
+
+	for !empty() {
+		tmp, tmp2 = remove()
+	}
+}

--- a/slow-increase-test.go
+++ b/slow-increase-test.go
@@ -52,3 +52,31 @@ func (t *Tests) SlowIncrease(b *testing.B, initInstance func(), add func(v inter
 		})
 	}
 }
+
+// SlowIncreaseTestObject tests the data structures performance by filling the data structures with n items, and then
+// sequentially removing 2 items and adding 1.
+// SlowIncreaseTestObject tests the data structures ability to slowly shrink while adding some elements to the data structure.
+// SlowIncreaseTestObject is a copy of SlowIncrease that operates on *TestValue object which allows data structures that suport
+// generics to not need to perform any type cast in the benchmark tests.
+func (t *Tests) SlowIncreaseTestObject(b *testing.B, initInstance func(), add func(v *TestValue), remove func() (*TestValue, bool), empty func() bool) {
+	for i, test := range tests {
+		// Doesn't run the first (0 items) test as 0 items makes no sense for this test.
+		if i == 0 {
+			continue
+		}
+
+		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				initInstance()
+				for i := 0; i < test.count; i++ {
+					add(GetTestValue(i))
+					add(GetTestValue(i))
+					tmp, tmp2 = remove()
+				}
+				for !empty() {
+					tmp, tmp2 = remove()
+				}
+			}
+		})
+	}
+}

--- a/stable-test.go
+++ b/stable-test.go
@@ -28,8 +28,40 @@ import (
 )
 
 // Stable tests the data structures performance by adding 1 item and removing it.
-// Stable  tests the data structures ability to handle constant add/remove over n iterations.
+// Stable tests the data structures ability to handle constant add/remove over n iterations.
 func (t *Tests) Stable(b *testing.B, initInstance func(), add func(v interface{}), remove func() (interface{}, bool), empty func() bool) {
+	initInstance()
+	for i := 0; i < fillCount; i++ {
+		add(GetTestValue(i))
+	}
+
+	for i, test := range tests {
+		// Doesn't run the first (0 items) test as 0 items makes no sense for this test.
+		if i == 0 {
+			continue
+		}
+
+		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				for i := 0; i < test.count; i++ {
+					add(GetTestValue(i))
+					tmp, tmp2 = remove()
+				}
+
+			}
+		})
+	}
+
+	for !empty() {
+		tmp, tmp2 = remove()
+	}
+}
+
+// StableTestObject tests the data structures performance by adding 1 item and removing it.
+// StableTestObject tests the data structures ability to handle constant add/remove over n iterations.
+// StableTestObject is a copy of Stable that operates on *TestValue object which allows data structures that suport
+// generics to not need to perform any type cast in the benchmark tests.
+func (t *Tests) StableTestObject(b *testing.B, initInstance func(), add func(v *TestValue), remove func() (*TestValue, bool), empty func() bool) {
 	initInstance()
 	for i := 0; i < fillCount; i++ {
 		add(GetTestValue(i))


### PR DESCRIPTION
Duplicated the existing tests so they operate on top of a known object (TestValue), which should allow data structures that supports generics to not need to perform any type casts during the tests implementation.